### PR TITLE
Alert user that bindings are missing, require NODE_BACKEND to bypass.

### DIFF
--- a/lib/sha256.js
+++ b/lib/sha256.js
@@ -11,6 +11,11 @@ try {
 } catch (e) {
   if (process.env.NODE_BACKEND === 'js')
     module.exports = require('./js/sha256');
-  else
+  else if (process.env.NODE_BACKEND === 'node')
     module.exports = require('./node/sha256');
+  else
+    throw new Error(
+      'Error locating bindings. '
+      + 'export NODE_BACKEND=<js|node> or rebuild bcrypto with node-gyp.'
+    )
 }


### PR DESCRIPTION
Address user concern in https://github.com/bcoin-org/bcoin/issues/572

Every crypto module in this package independently tries to `require('bindings')` but swallows the error and silently uses either `js` or `node` backends. 

This PR throws actually throws the error if the bindings are inaccessible, and advises the user to pick a "slow" backend by `export NODE_BACKEND=<js|node>`

This change is only applied to the `sha256.js` module, theoretically it could be applied to every single algo in the package but I think it's safe to assume that bcoin will always require sha256 at least once very early in the launch process.

I notice sha256 is also relied on here to export a package-wide property:
https://github.com/bcoin-org/bcrypto/blob/934f5ea45a0bc0926b9e7916f68bfeb2ea4881e3/lib/bcrypto.js#L92
