### PR TITLE
Return recovery with signatures.

### DIFF
--- a/lib/js/secp256k1.js
+++ b/lib/js/secp256k1.js
@@ -9,8 +9,32 @@
 
 const ECDSA = require('./ecdsa');
 
+class Secp256k1 extends ECDSA {
+  constructor() {
+    super('SECP256K1');
+  }
+
+  signRecoverable(msg, key) {
+    const sig = this._sign(msg, key);
+
+    return {
+      signature: sig.encode(this.size),
+      recovery: sig.param
+    };
+  }
+
+  signRecoverableDER(msg, key) {
+    const sig = this._sign(msg, key);
+
+    return {
+      signature: sig.toDER(this.size),
+      recovery: sig.param
+    };
+  }
+}
+
 /*
  * Expose
  */
 
-module.exports = new ECDSA('SECP256K1');
+module.exports = new Secp256k1();

--- a/lib/native/secp256k1.js
+++ b/lib/native/secp256k1.js
@@ -418,6 +418,24 @@ secp256k1.sign = function sign(msg, key) {
  * Sign a message.
  * @param {Buffer} msg
  * @param {Buffer} key - Private key.
+ * @returns {Object} R/S-formatted signature and recovery ID.
+ */
+
+secp256k1.signRecoverable = function signRecoverable(msg, key) {
+  // sign message.
+  const { signature, recovery } = binding.sign(truncate(msg), key);
+
+  // Ensure low S value.
+  return {
+    signature: binding.signatureNormalize(signature),
+    recovery: recovery
+  };
+};
+
+/**
+ * Sign a message.
+ * @param {Buffer} msg
+ * @param {Buffer} key - Private key.
  * @returns {Buffer} DER-formatted signature.
  */
 
@@ -427,6 +445,22 @@ secp256k1.signDER = function signDER(msg, key) {
 
   // Convert to DER.
   return binding.signatureExport(sig);
+};
+
+/**
+ * Sign a message.
+ * @param {Buffer} msg
+ * @param {Buffer} key - Private key.
+ * @returns {Object} DER-formatted signature and recovery ID.
+ */
+
+secp256k1.signRecoverableDER = function signRecoverableDER(msg, key) {
+  const { signature, recovery } = secp256k1.signRecoverable(msg, key);
+
+  return {
+    signature: binding.signatureExport(signature),
+    recovery: recovery
+  };
 };
 
 /**

--- a/test/ecdsa-test.js
+++ b/test/ecdsa-test.js
@@ -584,4 +584,46 @@ describe('ECDSA', function() {
       assert.strictEqual(curve.recover(msg, sig, 0), null);
     });
   }
+
+  it('should generate keypair, sign RS and recover', () => {
+    const msg = random.randomBytes(secp256k1n.size);
+    const priv = secp256k1n.privateKeyGenerate();
+    const pub = secp256k1n.publicKeyCreate(priv);
+    const pubu = secp256k1n.publicKeyConvert(pub, false);
+
+    const {
+      signature,
+      recovery
+    } = secp256k1n.signRecoverable(msg, priv);
+
+    assert(secp256k1n.verify(msg, signature, pub));
+    assert(secp256k1n.verify(msg, signature, pubu));
+
+    const rpub = secp256k1n.recover(msg, signature, recovery, true);
+    const rpubu = secp256k1n.recover(msg, signature, recovery, false);
+
+    assert.bufferEqual(rpub, pub);
+    assert.bufferEqual(rpubu, pubu);
+  });
+
+  it('should generate keypair, sign DER and recover', () => {
+    const msg = random.randomBytes(secp256k1n.size);
+    const priv = secp256k1n.privateKeyGenerate();
+    const pub = secp256k1n.publicKeyCreate(priv);
+    const pubu = secp256k1n.publicKeyConvert(pub, false);
+
+    const {
+      signature,
+      recovery
+    } = secp256k1n.signRecoverableDER(msg, priv);
+
+    assert(secp256k1n.verifyDER(msg, signature, pub));
+    assert(secp256k1n.verifyDER(msg, signature, pubu));
+
+    const rpub = secp256k1n.recoverDER(msg, signature, recovery, true);
+    const rpubu = secp256k1n.recoverDER(msg, signature, recovery, false);
+
+    assert.bufferEqual(rpub, pub);
+    assert.bufferEqual(rpubu, pubu);
+  });
 });


### PR DESCRIPTION
Adds two new api calls `signRecoverable` and `signRecoverableDER`.

It only adds these methods to `secp256k1`.
Even though `elliptic.js` can returns recovery for all curves,
bcrypto_ecdsa is based on OpenSSL.

Because bcrypto/secp256k1 is using different implementation that supports recovery, decided to expose these methods only for `lib/secp256k1`.

Addresses: https://github.com/bcoin-org/bcrypto/issues/4