### PR TITLE
ci: run tests for multiple backends.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,100 @@
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/node:10.15.3-browsers
+
+version: 2.0
+jobs:
+  install:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          # Use package.json in case we don't have package-lock
+          - v1-dependencies-{{ checksum "package.json" }}
+          # fallback to using the latest cache if no exact match is found
+          - v1-dependencies-
+      - run: npm install
+      - run: npm install eslint browserify babel-eslint
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+      - persist_to_workspace:
+          root: .
+          paths: .
+
+  test_browser:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test browser
+          command: npm run test-browser
+  test_node:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test with node backend
+          command: npm run test-node
+  test_native:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test with native backend
+          command: npm run test-native
+  test_js:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test with javascript backend
+          command: npm run test-js
+  test_js_bigint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Test with javascript backend and bigint
+          command: npm run test-bigint
+
+  lint:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Lint
+          command: npm run lint-ci
+
+workflows:
+  version: 2
+  test_and_lint:
+    jobs:
+      - install
+      - lint:
+          requires:
+            - install
+      - test_browser:
+          requires:
+            - install
+      - test_js:
+          requires:
+            - install
+      - test_js_bigint:
+          requires:
+            - install
+      - test_native:
+          requires:
+            - install
+      - test_node:
+          requires:
+            - install

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bcrypto
 
+[![Build Status][circleci-status-img]][circleci-status-url]
+
 The missing crypto module for node.js. bcrypto provides you with a consistent
 interface accross node.js and the browser.
 
@@ -71,3 +73,6 @@ See LICENSE for more info.
 [secp256k1]: https://github.com/bitcoin-core/secp256k1
 [ed25519]: https://github.com/floodyberry/ed25519-donna
 [safecurves]: https://safecurves.cr.yp.to/rigid.html
+
+[circleci-status-img]: https://circleci.com/gh/bcoin-org/bcrypto/tree/master.svg?style=shield
+[circleci-status-url]: https://circleci.com/gh/bcoin-org/bcrypto/tree/master

--- a/package.json
+++ b/package.json
@@ -20,13 +20,20 @@
   "scripts": {
     "install": "node-gyp rebuild || echo 'Build failed.'",
     "lint": "eslint bench/ lib/ test/ || exit 0",
-    "test": "bmocha -S --file ./scripts/post.js 'test/*-test.js'"
+    "lint-ci": "eslint bench/ lib/ test/",
+    "test": "bmocha -S --file ./scripts/post.js 'test/*-test.js'",
+    "test-native": "bmocha -B native -S --file ./scripts/post.js 'test/*-test.js'",
+    "test-node": "bmocha -B node -S 'test/*-test.js'",
+    "test-js": "bmocha -B js -S 'test/*-test.js'",
+    "test-browser": "bmocha -B js -H -S 'test/*-test.js'",
+    "test-bigint": "bmocha -B js -e BCRYPTO_FORCE_BIGINT=1 -S 'test/*-test.js'",
+    "test-all": "npm run test-browser && npm run test-native && npm run test-node && npm run test-js && npm run test-bigint"
   },
   "dependencies": {
     "bsert": "~0.0.10",
     "bufio": "~1.0.6",
     "loady": "~0.0.1",
-    "nan": "^2.13.1"
+    "nan": "^2.13.2"
   },
   "devDependencies": {
     "bmocha": "^2.1.0"


### PR DESCRIPTION
This only does build/test checks for multiple backends.
I have not included coverage yet, I need to investigate how to properly check coverage of
C/C++ codebase. We could include only JS coverage though.

Runs tests against v10.15.3
 - Compile
 - Lint
 - Tests browser version (headless chrome).
 - Tests node backend.
 - Tests native backend.
 - Tests js backend.
 - Tests js backend with enforced BigInts.

Add building badge.

Example PR: https://github.com/nodar-chkuaselidze/bcrypto/pull/1

It requires some permission from circleci @BluSyn.
Probably good idea to verify permissions (possibly compare to other CIs)