### PR TITLE
v12 deprecations

### DIFF
--- a/src/aead.cc
+++ b/src/aead.cc
@@ -36,7 +36,7 @@ BAEAD::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(aead_constructor);
 
-  target->Set(Nan::New("AEAD").ToLocalChecked(),
+  Nan::Set(target, Nan::New("AEAD").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/aes.cc
+++ b/src/aes.cc
@@ -15,7 +15,7 @@ BAES::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "encipher", BAES::Encipher);
   Nan::Export(obj, "decipher", BAES::Decipher);
 
-  target->Set(Nan::New("aes").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("aes").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BAES::Encipher) {

--- a/src/bcrypto.cc
+++ b/src/bcrypto.cc
@@ -70,11 +70,11 @@ NAN_METHOD(cleanse) {
 }
 
 NAN_MODULE_INIT(init) {
-  target->Set(Nan::New("major").ToLocalChecked(),
+  Nan::Set(target, Nan::New("major").ToLocalChecked(),
               Nan::New<v8::Uint32>(NODE_MAJOR_VERSION));
-  target->Set(Nan::New("minor").ToLocalChecked(),
+  Nan::Set(target, Nan::New("minor").ToLocalChecked(),
               Nan::New<v8::Uint32>(NODE_MINOR_VERSION));
-  target->Set(Nan::New("patch").ToLocalChecked(),
+  Nan::Set(target, Nan::New("patch").ToLocalChecked(),
               Nan::New<v8::Uint32>(NODE_PATCH_VERSION));
 
   BAEAD::Init(target);

--- a/src/blake2b.cc
+++ b/src/blake2b.cc
@@ -31,7 +31,7 @@ BBLAKE2b::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(blake2b_constructor);
 
-  target->Set(Nan::New("BLAKE2b").ToLocalChecked(),
+  Nan::Set(target, Nan::New("BLAKE2b").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/blake2s.cc
+++ b/src/blake2s.cc
@@ -31,7 +31,7 @@ BBLAKE2s::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(blake2s_constructor);
 
-  target->Set(Nan::New("BLAKE2s").ToLocalChecked(),
+  Nan::Set(target, Nan::New("BLAKE2s").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/chacha20.cc
+++ b/src/chacha20.cc
@@ -33,7 +33,7 @@ BChaCha20::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(chacha20_constructor);
 
-  target->Set(Nan::New("ChaCha20").ToLocalChecked(),
+  Nan::Set(target, Nan::New("ChaCha20").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/cipherbase.cc
+++ b/src/cipherbase.cc
@@ -56,7 +56,7 @@ BCipherBase::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(cipher_constructor);
 
-  target->Set(Nan::New("CipherBase").ToLocalChecked(),
+  Nan::Set(target, Nan::New("CipherBase").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/dsa.cc
+++ b/src/dsa.cc
@@ -36,7 +36,7 @@ BDSA::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "verify", BDSA::Verify);
   Nan::Export(obj, "derive", BDSA::Derive);
 
-  target->Set(Nan::New("dsa").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("dsa").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BDSA::ParamsGenerate) {
@@ -54,9 +54,9 @@ NAN_METHOD(BDSA::ParamsGenerate) {
     return Nan::ThrowTypeError("Could not generate key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -170,9 +170,9 @@ NAN_METHOD(BDSA::ParamsImport) {
     return Nan::ThrowError("Could not import params.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -211,11 +211,11 @@ NAN_METHOD(BDSA::PrivateKeyCreate) {
     return Nan::ThrowError("Could not generate key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->xd, k->xl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->xd, k->xl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -376,11 +376,11 @@ NAN_METHOD(BDSA::PrivateKeyImport) {
     return Nan::ThrowError("Could not import private key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->xd, k->xl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->xd, k->xl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -451,11 +451,11 @@ NAN_METHOD(BDSA::PrivateKeyImportPKCS8) {
     return Nan::ThrowError("Could not import private key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->xd, k->xl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->xd, k->xl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -557,10 +557,10 @@ NAN_METHOD(BDSA::PublicKeyImport) {
     return Nan::ThrowError("Could not import public key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -626,10 +626,10 @@ NAN_METHOD(BDSA::PublicKeyImportSPKI) {
     return Nan::ThrowError("Could not import public key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->yd, k->yl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 
@@ -686,8 +686,8 @@ NAN_METHOD(BDSA::Sign) {
     return Nan::ThrowError("Could not sign message.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::NewBuffer((char *)r, rl).ToLocalChecked());
-  ret->Set(1, Nan::NewBuffer((char *)s, sl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::NewBuffer((char *)r, rl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::NewBuffer((char *)s, sl).ToLocalChecked());
 
   info.GetReturnValue().Set(ret);
 }

--- a/src/dsa_async.cc
+++ b/src/dsa_async.cc
@@ -35,9 +35,9 @@ BDSAWorker::HandleOKCallback() {
   assert(k);
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->gd, k->gl).ToLocalChecked());
 
   bcrypto_dsa_key_free(k);
 

--- a/src/ecdsa.cc
+++ b/src/ecdsa.cc
@@ -37,7 +37,7 @@ BECDSA::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "recover", BECDSA::Recover);
   Nan::Export(obj, "derive", BECDSA::Derive);
 
-  target->Set(Nan::New("ecdsa").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("ecdsa").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BECDSA::PrivateKeyGenerate) {
@@ -722,8 +722,8 @@ NAN_METHOD(BECDSA::Sign) {
     return Nan::ThrowError("Could not sign.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::NewBuffer((char *)r, rl).ToLocalChecked());
-  ret->Set(1, Nan::NewBuffer((char *)s, sl).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::NewBuffer((char *)r, rl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::NewBuffer((char *)s, sl).ToLocalChecked());
 
   info.GetReturnValue().Set(ret);
 }

--- a/src/ed25519.cc
+++ b/src/ed25519.cc
@@ -38,7 +38,7 @@ BED25519::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "exchange", BED25519::Exchange);
   Nan::Export(obj, "exchangeWithScalar", BED25519::ExchangeWithScalar);
 
-  target->Set(Nan::New("ed25519").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("ed25519").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BED25519::PrivateKeyConvert) {
@@ -827,13 +827,13 @@ NAN_METHOD(BED25519::BatchVerify) {
   const uint8_t **sigs = &slab1[len * 2];
 
   for (size_t i = 0; i < len; i++) {
-    if (!batch->Get(i)->IsArray()) {
+    if (!Nan::Get(batch, i).ToLocalChecked()->IsArray()) {
       free(slab1);
       free(slab2);
       return Nan::ThrowTypeError("Batch item must be an array.");
     }
 
-    v8::Local<v8::Array> item = batch->Get(i).As<v8::Array>();
+    v8::Local<v8::Array> item = Nan::Get(batch, i).ToLocalChecked().As<v8::Array>();
 
     if (item->Length() != 3) {
       free(slab1);
@@ -841,9 +841,9 @@ NAN_METHOD(BED25519::BatchVerify) {
       return Nan::ThrowError("Invalid input.");
     }
 
-    v8::Local<v8::Object> mbuf = item->Get(0).As<v8::Object>();
-    v8::Local<v8::Object> sbuf = item->Get(1).As<v8::Object>();
-    v8::Local<v8::Object> pbuf = item->Get(2).As<v8::Object>();
+    v8::Local<v8::Object> mbuf = Nan::Get(item, 0).ToLocalChecked().As<v8::Object>();
+    v8::Local<v8::Object> sbuf = Nan::Get(item, 1).ToLocalChecked().As<v8::Object>();
+    v8::Local<v8::Object> pbuf = Nan::Get(item, 2).ToLocalChecked().As<v8::Object>();
 
     if (!node::Buffer::HasInstance(mbuf)
         || !node::Buffer::HasInstance(sbuf)

--- a/src/ed448.cc
+++ b/src/ed448.cc
@@ -37,7 +37,7 @@ BED448::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "exchange", BED448::Exchange);
   Nan::Export(obj, "exchangeWithScalar", BED448::ExchangeWithScalar);
 
-  target->Set(Nan::New("ed448").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("ed448").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BED448::PrivateKeyConvert) {

--- a/src/hash160.cc
+++ b/src/hash160.cc
@@ -32,7 +32,7 @@ BHash160::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(hash160_constructor);
 
-  target->Set(Nan::New("Hash160").ToLocalChecked(),
+  Nan::Set(target, Nan::New("Hash160").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/hash256.cc
+++ b/src/hash256.cc
@@ -31,7 +31,7 @@ BHash256::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(hash256_constructor);
 
-  target->Set(Nan::New("Hash256").ToLocalChecked(),
+  Nan::Set(target, Nan::New("Hash256").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/keccak.cc
+++ b/src/keccak.cc
@@ -31,7 +31,7 @@ BKeccak::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(keccak_constructor);
 
-  target->Set(Nan::New("Keccak").ToLocalChecked(),
+  Nan::Set(target, Nan::New("Keccak").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/md4.cc
+++ b/src/md4.cc
@@ -31,7 +31,7 @@ BMD4::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(md4_constructor);
 
-  target->Set(Nan::New("MD4").ToLocalChecked(),
+  Nan::Set(target, Nan::New("MD4").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/md5.cc
+++ b/src/md5.cc
@@ -31,7 +31,7 @@ BMD5::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(md5_constructor);
 
-  target->Set(Nan::New("MD5").ToLocalChecked(),
+  Nan::Set(target, Nan::New("MD5").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/murmur3.cc
+++ b/src/murmur3.cc
@@ -15,7 +15,7 @@ BMurmur3::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "sum", BMurmur3::Sum);
   Nan::Export(obj, "tweak", BMurmur3::Tweak);
 
-  target->Set(Nan::New("murmur3").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("murmur3").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BMurmur3::Sum) {

--- a/src/pbkdf2.cc
+++ b/src/pbkdf2.cc
@@ -18,7 +18,7 @@ BPBKDF2::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "deriveAsync", BPBKDF2::DeriveAsync);
   Nan::Export(obj, "hasHash", BPBKDF2::HasHash);
 
-  target->Set(Nan::New("pbkdf2").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("pbkdf2").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BPBKDF2::Derive) {

--- a/src/poly1305.cc
+++ b/src/poly1305.cc
@@ -30,7 +30,7 @@ BPoly1305::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(poly1305_constructor);
 
-  target->Set(Nan::New("Poly1305").ToLocalChecked(),
+  Nan::Set(target, Nan::New("Poly1305").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/random.cc
+++ b/src/random.cc
@@ -14,7 +14,7 @@ BRandom::Init(v8::Local<v8::Object> &target) {
 
   Nan::Export(obj, "randomFill", BRandom::RandomFill);
 
-  target->Set(Nan::New("random").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("random").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BRandom::RandomFill) {

--- a/src/ripemd160.cc
+++ b/src/ripemd160.cc
@@ -31,7 +31,7 @@ BRIPEMD160::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(ripemd160_constructor);
 
-  target->Set(Nan::New("RIPEMD160").ToLocalChecked(),
+  Nan::Set(target, Nan::New("RIPEMD160").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/rsa.cc
+++ b/src/rsa.cc
@@ -42,7 +42,7 @@ BRSA::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "unveil", BRSA::Unveil);
   Nan::Export(obj, "hasHash", BRSA::HasHash);
 
-  target->Set(Nan::New("rsa").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("rsa").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BRSA::PrivateKeyGenerate) {
@@ -65,14 +65,14 @@ NAN_METHOD(BRSA::PrivateKeyGenerate) {
     return Nan::ThrowError("Could not generate key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
-  ret->Set(6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
-  ret->Set(7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
+  Nan::Set(ret, 6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
+  Nan::Set(ret, 7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 
@@ -166,12 +166,12 @@ NAN_METHOD(BRSA::PrivateKeyCompute) {
     return info.GetReturnValue().Set(Nan::Null());
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
-  ret->Set(5, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
+  Nan::Set(ret, 5, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 
@@ -313,14 +313,14 @@ NAN_METHOD(BRSA::PrivateKeyImport) {
     return Nan::ThrowError("Could not import private key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
-  ret->Set(6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
-  ret->Set(7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
+  Nan::Set(ret, 6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
+  Nan::Set(ret, 7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 
@@ -406,14 +406,14 @@ NAN_METHOD(BRSA::PrivateKeyImportPKCS8) {
     return Nan::ThrowError("Could not import private key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
-  ret->Set(6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
-  ret->Set(7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
+  Nan::Set(ret, 6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
+  Nan::Set(ret, 7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 
@@ -495,8 +495,8 @@ NAN_METHOD(BRSA::PublicKeyImport) {
     return Nan::ThrowError("Could not import public key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 
@@ -552,8 +552,8 @@ NAN_METHOD(BRSA::PublicKeyImportSPKI) {
     return Nan::ThrowError("Could not import public key.");
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 

--- a/src/rsa_async.cc
+++ b/src/rsa_async.cc
@@ -37,14 +37,14 @@ BRSAWorker::HandleOKCallback() {
   assert(k);
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
-  ret->Set(1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
-  ret->Set(2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
-  ret->Set(3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
-  ret->Set(4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
-  ret->Set(5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
-  ret->Set(6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
-  ret->Set(7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
+  Nan::Set(ret, 0, Nan::CopyBuffer((char *)k->nd, k->nl).ToLocalChecked());
+  Nan::Set(ret, 1, Nan::CopyBuffer((char *)k->ed, k->el).ToLocalChecked());
+  Nan::Set(ret, 2, Nan::CopyBuffer((char *)k->dd, k->dl).ToLocalChecked());
+  Nan::Set(ret, 3, Nan::CopyBuffer((char *)k->pd, k->pl).ToLocalChecked());
+  Nan::Set(ret, 4, Nan::CopyBuffer((char *)k->qd, k->ql).ToLocalChecked());
+  Nan::Set(ret, 5, Nan::CopyBuffer((char *)k->dpd, k->dpl).ToLocalChecked());
+  Nan::Set(ret, 6, Nan::CopyBuffer((char *)k->dqd, k->dql).ToLocalChecked());
+  Nan::Set(ret, 7, Nan::CopyBuffer((char *)k->qid, k->qil).ToLocalChecked());
 
   bcrypto_rsa_key_free(k);
 

--- a/src/scrypt.cc
+++ b/src/scrypt.cc
@@ -16,7 +16,7 @@ BScrypt::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "derive", BScrypt::Derive);
   Nan::Export(obj, "deriveAsync", BScrypt::DeriveAsync);
 
-  target->Set(Nan::New("scrypt").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("scrypt").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BScrypt::Derive) {

--- a/src/secp256k1.cc
+++ b/src/secp256k1.cc
@@ -255,7 +255,7 @@ BSecp256k1::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "schnorrSign", BSecp256k1::schnorrSign);
   Nan::Export(obj, "schnorrVerify", BSecp256k1::schnorrVerify);
 
-  target->Set(Nan::New("secp256k1").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("secp256k1").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BSecp256k1::privateKeyVerify) {
@@ -526,7 +526,8 @@ NAN_METHOD(BSecp256k1::publicKeyCombine) {
   std::unique_ptr<secp256k1_pubkey[]> public_keys(new secp256k1_pubkey[input_buffers->Length()]);
   std::unique_ptr<secp256k1_pubkey*[]> ins(new secp256k1_pubkey*[input_buffers->Length()]);
   for (unsigned int i = 0; i < input_buffers->Length(); ++i) {
-    v8::Local<v8::Object> public_key_buffer = v8::Local<v8::Object>::Cast(input_buffers->Get(i));
+    v8::Local<v8::Object> public_key_buffer = v8::Local<v8::Object>::Cast(
+        Nan::Get(input_buffers, i).ToLocalChecked());
     CHECK_TYPE_BUFFER(public_key_buffer, EC_PUBLIC_KEY_TYPE_INVALID);
     CHECK_BUFFER_LENGTH2(public_key_buffer, 33, 65, EC_PUBLIC_KEY_LENGTH_INVALID);
 
@@ -684,8 +685,8 @@ NAN_METHOD(BSecp256k1::sign) {
   secp256k1_ecdsa_recoverable_signature_serialize_compact(secp256k1ctx, &output[0], &recid, &sig);
 
   v8::Local<v8::Object> obj = Nan::New<v8::Object>();
-  obj->Set(Nan::New<v8::String>("signature").ToLocalChecked(), COPY_BUFFER(&output[0], 64));
-  obj->Set(Nan::New<v8::String>("recovery").ToLocalChecked(), Nan::New<v8::Number>(recid));
+  Nan::Set(obj, Nan::New<v8::String>("signature").ToLocalChecked(), COPY_BUFFER(&output[0], 64));
+  Nan::Set(obj, Nan::New<v8::String>("recovery").ToLocalChecked(), Nan::New<v8::Number>(recid));
   info.GetReturnValue().Set(obj);
 }
 

--- a/src/sha1.cc
+++ b/src/sha1.cc
@@ -31,7 +31,7 @@ BSHA1::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(sha1_constructor);
 
-  target->Set(Nan::New("SHA1").ToLocalChecked(),
+  Nan::Set(target, Nan::New("SHA1").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/sha224.cc
+++ b/src/sha224.cc
@@ -31,7 +31,7 @@ BSHA224::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(sha224_constructor);
 
-  target->Set(Nan::New("SHA224").ToLocalChecked(),
+  Nan::Set(target, Nan::New("SHA224").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/sha256.cc
+++ b/src/sha256.cc
@@ -31,7 +31,7 @@ BSHA256::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(sha256_constructor);
 
-  target->Set(Nan::New("SHA256").ToLocalChecked(),
+  Nan::Set(target, Nan::New("SHA256").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/sha384.cc
+++ b/src/sha384.cc
@@ -31,7 +31,7 @@ BSHA384::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(sha384_constructor);
 
-  target->Set(Nan::New("SHA384").ToLocalChecked(),
+  Nan::Set(target, Nan::New("SHA384").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/sha512.cc
+++ b/src/sha512.cc
@@ -31,7 +31,7 @@ BSHA512::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(sha512_constructor);
 
-  target->Set(Nan::New("SHA512").ToLocalChecked(),
+  Nan::Set(target, Nan::New("SHA512").ToLocalChecked(),
     Nan::GetFunction(ctor).ToLocalChecked());
 }
 

--- a/src/siphash.cc
+++ b/src/siphash.cc
@@ -22,7 +22,8 @@ BSiphash::Init(v8::Local<v8::Object> &target) {
   Nan::Export(obj, "siphash64k256", BSiphash::Siphash64k256);
   Nan::Export(obj, "sipmod", BSiphash::Sipmod);
 
-  target->Set(Nan::New("siphash").ToLocalChecked(), obj);
+  //target->Set(Nan::New("siphash").ToLocalChecked(), obj);
+  Nan::Set(target, Nan::New("siphash").ToLocalChecked(), obj);
 }
 
 NAN_METHOD(BSiphash::Siphash) {
@@ -51,8 +52,9 @@ NAN_METHOD(BSiphash::Siphash) {
   uint64_t result = bcrypto_siphash(data, len, kdata);
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
-  ret->Set(1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
+
+  Nan::Set(ret, 0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
+  Nan::Set(ret, 1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
 
   info.GetReturnValue().Set(ret);
 }
@@ -110,8 +112,8 @@ NAN_METHOD(BSiphash::Siphash64) {
   uint64_t result = bcrypto_siphash64(num, kdata);
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
-  ret->Set(1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
+  Nan::Set(ret, 0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
+  Nan::Set(ret, 1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
 
   info.GetReturnValue().Set(ret);
 }
@@ -169,8 +171,8 @@ NAN_METHOD(BSiphash::Siphash64k256) {
   uint64_t result = bcrypto_siphash64k256(num, kdata);
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
-  ret->Set(1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
+  Nan::Set(ret, 0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
+  Nan::Set(ret, 1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
 
   info.GetReturnValue().Set(ret);
 }
@@ -211,8 +213,8 @@ NAN_METHOD(BSiphash::Sipmod) {
   uint64_t result = bcrypto_sipmod(data, len, kdata, m);
 
   v8::Local<v8::Array> ret = Nan::New<v8::Array>();
-  ret->Set(0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
-  ret->Set(1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
+  Nan::Set(ret, 0, Nan::New<v8::Int32>((int32_t)(result >> 32)));
+  Nan::Set(ret, 1, Nan::New<v8::Int32>((int32_t)(result & 0xffffffff)));
 
   info.GetReturnValue().Set(ret);
 }

--- a/src/whirlpool.cc
+++ b/src/whirlpool.cc
@@ -31,8 +31,8 @@ BWhirlpool::Init(v8::Local<v8::Object> &target) {
   v8::Local<v8::FunctionTemplate> ctor =
     Nan::New<v8::FunctionTemplate>(whirlpool_constructor);
 
-  target->Set(Nan::New("Whirlpool").ToLocalChecked(),
-    Nan::GetFunction(ctor).ToLocalChecked());
+  Nan::Set(target, Nan::New("Whirlpool").ToLocalChecked(),
+      Nan::GetFunction(ctor).ToLocalChecked()).FromJust();
 }
 
 NAN_METHOD(BWhirlpool::New) {


### PR DESCRIPTION
I was testing locally and replaced:
  obj->Set(..) with Nan::Set(obj, )
and
  obj->Get(..) with Nan::Get(obj, ..).ToLocalChecked()

I don't think we were doing error checking before, so ToLocalChecked should behave the same way.
Unless we want to add checks (and related macros).

