### PR TITLE
bindings: fix build for windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -174,7 +174,15 @@
         ],
         "include_dirs": [
           "<(openssl_root)/include"
-        ]
+        ],
+	"msbuild_settings": {
+	  'ClCompile': {
+	    'ObjectFileName': '$(IntDir)/%(Directory)/%(Filename)',
+	  },
+	  "Link": {
+	    "ImageHasSafeExceptionHandlers": "false"
+	  }
+	},
       }, {
         "include_dirs": [
           "<(node_root_dir)/deps/openssl/openssl/include"

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,7 +1,7 @@
 {
   "variables": {
     "bcrypto_byteorder%":
-      "<!(python -c 'from __future__ import print_function; import sys; print(sys.byteorder)')",
+      "<!(python -c \"from __future__ import print_function; import sys; print(sys.byteorder)\")",
   },
   "targets": [{
     "target_name": "bcrypto",

--- a/src/cipherbase.h
+++ b/src/cipherbase.h
@@ -6,6 +6,13 @@
 
 #include "openssl/evp.h"
 
+#if defined(_WIN32) || defined(_WIN64)
+  #define snprintf _snprintf
+  #define vsnprintf _vsnprintf
+  #define strcasecmp _stricmp
+  #define strncasecmp _strnicmp
+#endif
+
 class BCipherBase : public Nan::ObjectWrap {
 public:
   static NAN_METHOD(New);


### PR DESCRIPTION
Faced some issues building for windows, trying to fix them.

- [x] Fixed `gmp.h` not found - `bn.cc` (needs rebase on master)
- [x] Fixed `cipherbase.h` string functions
- [x] Fixed `bindings.gyp` byte order issue
- [x] Linking fails - Fixed (see https://stackoverflow.com/a/3731577)