### PR TITLE
bn: use BigInt function over literals

### DIFF
--- a/lib/node/bn.js
+++ b/lib/node/bn.js
@@ -43,13 +43,13 @@ const {custom} = require('../internal/custom');
  * Constants
  */
 
-const U8_MAX = (1n << 8n) - 1n;
-const U16_MAX = (1n << 16n) - 1n;
-const U32_MAX = (1n << 32n) - 1n;
-const U64_MAX = (1n << 64n) - 1n;
-const U128_MAX = (1n << 128n) - 1n;
-const U256_MAX = (1n << 256n) - 1n;
-const MAX_SAFE_INTEGER = 9007199254740991n;
+const U8_MAX = (BigInt(1) << BigInt(8)) - BigInt(1);
+const U16_MAX = (BigInt(1) << BigInt(16)) - BigInt(1);
+const U32_MAX = (BigInt(1) << BigInt(32)) - BigInt(1);
+const U64_MAX = (BigInt(1) << BigInt(64)) - BigInt(1);
+const U128_MAX = (BigInt(1) << BigInt(128)) - BigInt(1);
+const U256_MAX = (BigInt(1) << BigInt(256)) - BigInt(1);
+const MAX_SAFE_INTEGER = BigInt(9007199254740991);
 const ENDIAN = new Int8Array(new Int16Array([1]).buffer)[0] === 0 ? 'be' : 'le';
 
 const primes = {
@@ -67,7 +67,7 @@ const primes = {
 
 class BN {
   constructor(num, base, endian) {
-    this.n = 0n;
+    this.n = BigInt(0);
     this.red = null;
     this.from(num, base, endian);
   }
@@ -77,7 +77,7 @@ class BN {
    */
 
   get negative() {
-    return this.n < 0n ? 1 : 0;
+    return this.n < BigInt(0) ? 1 : 0;
   }
 
   set negative(val) {
@@ -179,7 +179,7 @@ class BN {
 
   quorem(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
 
     const [q, r] = quorem(this.n, num.n);
 
@@ -192,7 +192,7 @@ class BN {
 
   iquo(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
 
     this.n /= num.n;
 
@@ -222,7 +222,7 @@ class BN {
 
   irem(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
 
     this.n %= num.n;
 
@@ -258,7 +258,7 @@ class BN {
 
   divmod(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
 
     const [q, r] = divmod(this.n, num.n);
 
@@ -271,7 +271,7 @@ class BN {
 
   idiv(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
 
     this.n = div(this.n, num.n);
 
@@ -301,7 +301,7 @@ class BN {
 
   imod(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
 
     this.n = mod(this.n, num.n);
 
@@ -337,7 +337,7 @@ class BN {
 
   divRound(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    nonzero(num.n !== 0n);
+    nonzero(num.n !== BigInt(0));
     return new BN(divRound(this.n, num.n));
   }
 
@@ -370,7 +370,7 @@ class BN {
   }
 
   isqr() {
-    this.n **= 2n;
+    this.n **= BigInt(2);
     return this;
   }
 
@@ -451,7 +451,7 @@ class BN {
 
     const n = this.n & BigInt(num);
 
-    if (n < -0x3ffffffn || n > 0x3ffffffn)
+    if (n < BigInt(-0x3ffffff) || n > BigInt(0x3ffffff))
       throw new RangeError('Number exceeds 26 bits.');
 
     return Number(n);
@@ -633,7 +633,7 @@ class BN {
 
   ishl(num) {
     enforce(BN.isBN(num), 'bits', 'bignum');
-    enforce(num.n >= 0n && num.n <= U32_MAX, 'bits', 'uint32');
+    enforce(num.n >= BigInt(0) && num.n <= U32_MAX, 'bits', 'uint32');
 
     this.n <<= num.n;
 
@@ -662,7 +662,7 @@ class BN {
 
   iushl(num) {
     enforce(BN.isBN(num), 'bits', 'bignum');
-    enforce(num.n >= 0n && num.n <= U32_MAX, 'bits', 'uint32');
+    enforce(num.n >= BigInt(0) && num.n <= U32_MAX, 'bits', 'uint32');
 
     this.n <<= num.n;
 
@@ -691,7 +691,7 @@ class BN {
 
   ishr(num) {
     enforce(BN.isBN(num), 'bits', 'bignum');
-    enforce(num.n >= 0n && num.n <= U32_MAX, 'bits', 'uint32');
+    enforce(num.n >= BigInt(0) && num.n <= U32_MAX, 'bits', 'uint32');
 
     this.n >>= num.n;
 
@@ -720,7 +720,7 @@ class BN {
 
   iushr(num) {
     enforce(BN.isBN(num), 'bits', 'bignum');
-    enforce(num.n >= 0n && num.n <= U32_MAX, 'bits', 'uint32');
+    enforce(num.n >= BigInt(0) && num.n <= U32_MAX, 'bits', 'uint32');
 
     this.n = ushr(this.n, num.n);
 
@@ -893,27 +893,27 @@ class BN {
   }
 
   sign() {
-    return (this.n > 0n) - (this.n < 0n);
+    return (this.n > BigInt(0)) - (this.n < BigInt(0));
   }
 
   isZero() {
-    return this.n === 0n;
+    return this.n === BigInt(0);
   }
 
   isNeg() {
-    return this.n < 0n;
+    return this.n < BigInt(0);
   }
 
   isPos() {
-    return this.n >= 0n;
+    return this.n >= BigInt(0);
   }
 
   isOdd() {
-    return (this.n & 1n) === 1n;
+    return (this.n & BigInt(1)) === BigInt(1);
   }
 
   isEven() {
-    return (this.n & 1n) === 0n;
+    return (this.n & BigInt(1)) === BigInt(0);
   }
 
   /*
@@ -983,7 +983,7 @@ class BN {
 
   iinvert(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    range(num.n >= 1n, 'iinvert');
+    range(num.n >= BigInt(1), 'iinvert');
 
     this.n = invert(this.n, num.n);
 
@@ -996,7 +996,7 @@ class BN {
 
   ifermat(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    range(num.n >= 1n, 'ifermat');
+    range(num.n >= BigInt(1), 'ifermat');
 
     this.n = fermat(this.n, num.n);
 
@@ -1010,7 +1010,7 @@ class BN {
   ipowm(y, m, mont, size) {
     enforce(BN.isBN(y), 'y', 'bignum');
     enforce(BN.isBN(m), 'm', 'bignum');
-    range(m.n >= 1n, 'ipowm');
+    range(m.n >= BigInt(1), 'ipowm');
     nonred(!this.red && !y.red, 'ipowm');
 
     this.n = powm(this.n, y.n, m.n, size);
@@ -1025,7 +1025,7 @@ class BN {
   ipowmn(y, m, mont) {
     enforce(isSMI(y), 'y', 'smi');
     enforce(BN.isBN(m), 'm', 'bignum');
-    range(m.n >= 1n, 'ipowmn');
+    range(m.n >= BigInt(1), 'ipowmn');
     nonred(!this.red, 'ipowmn');
 
     this.n = powm(this.n, BigInt(y), m.n);
@@ -1039,7 +1039,7 @@ class BN {
 
   isqrtm(p) {
     enforce(BN.isBN(p), 'p', 'bignum');
-    range(p.n >= 1n, 'isqrtm');
+    range(p.n >= BigInt(1), 'isqrtm');
     nonred(!this.red, 'isqrtm');
 
     this.n = sqrtm(this.n, p.n);
@@ -1054,8 +1054,8 @@ class BN {
   isqrtpq(p, q) {
     enforce(BN.isBN(p), 'p', 'bignum');
     enforce(BN.isBN(q), 'q', 'bignum');
-    range(p.n >= 1n, 'isqrtpq');
-    range(q.n >= 1n, 'isqrtpq');
+    range(p.n >= BigInt(1), 'isqrtpq');
+    range(q.n >= BigInt(1), 'isqrtpq');
     nonred(!this.red, 'isqrtpq');
 
     this.n = sqrtpq(this.n, p.n, q.n);
@@ -1222,7 +1222,7 @@ class BN {
 
   redShl(num) {
     enforce(BN.isBN(num), 'num', 'bignum');
-    enforce(num.n >= 0n && num.n <= U32_MAX, 'num', 'uint32');
+    enforce(num.n >= BigInt(0) && num.n <= U32_MAX, 'num', 'uint32');
     red(this.red, 'redShl');
     nonred(!num.red, 'redShl');
     return this.red.shl(this, num);
@@ -1383,7 +1383,7 @@ class BN {
   }
 
   reverse() {
-    const neg = this.n < 0n;
+    const neg = this.n < BigInt(0);
     const endian = ENDIAN === 'be' ? 'le' : 'be';
 
     this.fromBuffer(this.toBuffer(endian), ENDIAN);
@@ -1434,15 +1434,15 @@ class BN {
   }
 
   czero() {
-    return (this.n === 0n) | 0;
+    return (this.n === BigInt(0)) | 0;
   }
 
   cneg() {
-    return (this.n < 0n) | 0;
+    return (this.n < BigInt(0)) | 0;
   }
 
   cpos() {
-    return (this.n >= 0n) | 0;
+    return (this.n >= BigInt(0)) | 0;
   }
 
   ceq(num) {
@@ -1511,7 +1511,7 @@ class BN {
   }
 
   toBool() {
-    return this.n !== 0n;
+    return this.n !== BigInt(0);
   }
 
   toString(base, padding) {
@@ -1975,7 +1975,7 @@ class Red {
 
     enforce(BN.isBN(m), 'm', 'bignum');
     nonred(!m.red, 'reduction');
-    range(m.n >= 1n, 'reduction');
+    range(m.n >= BigInt(1), 'reduction');
 
     this.m = m.n;
     this.prime = prime;
@@ -2029,7 +2029,7 @@ class Red {
 
     let n = BigInt(num);
 
-    if (this.m < 0x4000000n)
+    if (this.m < BigInt(0x4000000))
       n %= this.m;
 
     a.n += n;
@@ -2049,7 +2049,7 @@ class Red {
 
     a.n -= b.n;
 
-    if (a.n < 0n)
+    if (a.n < BigInt(0))
       a.n += this.m;
 
     return a;
@@ -2067,12 +2067,12 @@ class Red {
 
     let n = BigInt(num);
 
-    if (this.m < 0x4000000n)
+    if (this.m < BigInt(0x4000000))
       n %= this.m;
 
     a.n -= n;
 
-    if (a.n < 0n)
+    if (a.n < BigInt(0))
       a.n += this.m;
 
     return a;
@@ -2112,7 +2112,7 @@ class Red {
   isqr(a) {
     this._verify1(a);
 
-    a.n **= 2n;
+    a.n **= BigInt(2);
     a.n %= this.m;
 
     return a;
@@ -2151,7 +2151,7 @@ class Red {
   ineg(a) {
     this._verify1(a);
 
-    if (a.n !== 0n)
+    if (a.n !== BigInt(0))
       a.n = this.m - a.n;
 
     return a;
@@ -2169,7 +2169,7 @@ class Red {
   cmpn(a, num) {
     this._verify1(a);
 
-    if (this.m < 0x4000000n) {
+    if (this.m < BigInt(0x4000000)) {
       const m = Number(this.m);
 
       num %= m;
@@ -2394,7 +2394,7 @@ function reverse(data) {
  */
 
 function quorem(x, y) {
-  assert(y !== 0n);
+  assert(y !== BigInt(0));
 
   const q = x / y;
   const r = x - (q * y);
@@ -2416,17 +2416,17 @@ function remrn(x, y) {
  */
 
 function divmod(x, y) {
-  assert(y !== 0n);
+  assert(y !== BigInt(0));
 
   let q = x / y;
   let r = x - (q * y);
 
-  if (r < 0n) {
-    if (y < 0n) {
-      q += 1n;
+  if (r < BigInt(0)) {
+    if (y < BigInt(0)) {
+      q += BigInt(1);
       r -= y;
     } else {
-      q -= 1n;
+      q -= BigInt(1);
       r += y;
     }
   }
@@ -2439,20 +2439,20 @@ function divmod(x, y) {
  */
 
 function div(x, y) {
-  assert(y !== 0n);
+  assert(y !== BigInt(0));
 
   let q = x / y;
 
-  if (x >= 0n)
+  if (x >= BigInt(0))
     return q;
 
   const r = x - (q * y);
 
-  if (r < 0n) {
-    if (y < 0n)
-      q += 1n;
+  if (r < BigInt(0)) {
+    if (y < BigInt(0))
+      q += BigInt(1);
     else
-      q -= 1n;
+      q -= BigInt(1);
   }
 
   return q;
@@ -2463,12 +2463,12 @@ function div(x, y) {
  */
 
 function mod(x, y) {
-  assert(y !== 0n);
+  assert(y !== BigInt(0));
 
   let r = x % y;
 
-  if (r < 0n) {
-    if (y < 0n)
+  if (r < BigInt(0)) {
+    if (y < BigInt(0))
       r -= y;
     else
       r += y;
@@ -2495,11 +2495,11 @@ function modrn(x, y) {
  */
 
 function divRound(x, y) {
-  assert(y !== 0n);
+  assert(y !== BigInt(0));
 
-  const half = y < 0n ? -(-y >> 1n) : (y >> 1n);
+  const half = y < BigInt(0) ? -(-y >> BigInt(1)) : (y >> BigInt(1));
 
-  if ((x < 0n) ^ (y < 0n))
+  if ((x < BigInt(0)) ^ (y < BigInt(0)))
     return (x - half) / y;
 
   return (x + half) / y;
@@ -2513,19 +2513,19 @@ function _rootrem(y, pow, rem) {
   if (pow === 0)
     throw new RangeError('Zeroth root.');
 
-  if (~pow & (y < 0n))
+  if (~pow & (y < BigInt(0)))
     throw new RangeError('Negative with even root.');
 
-  if (y === -1n || y === 0n || y === 1n)
-    return [y, 0n];
+  if (y === BigInt(-1) || y === BigInt(0) || y === BigInt(1))
+    return [y, BigInt(0)];
 
   const exp = BigInt(pow);
 
-  let u = 0n;
-  let t = 1n << BigInt(bitLength(y) / pow + 1 | 0);
+  let u = BigInt(0);
+  let t = BigInt(1) << BigInt(bitLength(y) / pow + 1 | 0);
   let v, r;
 
-  if (y < 0n)
+  if (y < BigInt(0))
     t = -t;
 
   if (pow === 2) {
@@ -2533,14 +2533,14 @@ function _rootrem(y, pow, rem) {
       u = t;
       t = y / u;
       t += u;
-      t >>= 1n;
+      t >>= BigInt(1);
     } while (ucmp(t, u) < 0);
   } else {
     do {
       u = t;
-      t = u ** (exp - 1n);
+      t = u ** (exp - BigInt(1));
       t = y / t;
-      v = u * (exp - 1n);
+      v = u * (exp - BigInt(1));
       t += v;
       t /= exp;
     } while (ucmp(t, u) < 0);
@@ -2563,12 +2563,12 @@ function root(y, pow) {
 }
 
 function isPower(y, pow) {
-  if (pow === 0 || (~pow & (y < 0n)))
+  if (pow === 0 || (~pow & (y < BigInt(0))))
     return false;
 
   const [, r] = rootrem(y, pow);
 
-  return r === 0n;
+  return r === BigInt(0);
 }
 
 function sqrtrem(y) {
@@ -2580,7 +2580,7 @@ function sqrt(y) {
 }
 
 function isSquare(y) {
-  if (y === 0n)
+  if (y === BigInt(0))
     return true;
 
   return isPower(y, 2);
@@ -2591,11 +2591,11 @@ function isSquare(y) {
  */
 
 function mask(width) {
-  return (1n << BigInt(width)) - 1n;
+  return (BigInt(1) << BigInt(width)) - BigInt(1);
 }
 
 function uand(x, y) {
-  const neg = x < 0n;
+  const neg = x < BigInt(0);
   const num = abs(x) & abs(y);
   return neg ? -num : num;
 }
@@ -2605,7 +2605,7 @@ function uandn(x, y) {
 }
 
 function uor(x, y) {
-  const neg = x < 0n;
+  const neg = x < BigInt(0);
   const num = abs(x) | abs(y);
   return neg ? -num : num;
 }
@@ -2615,7 +2615,7 @@ function uorn(x, y) {
 }
 
 function uxor(x, y) {
-  const neg = x < 0n;
+  const neg = x < BigInt(0);
   const num = abs(x) ^ abs(y);
   return neg ? -num : num;
 }
@@ -2625,7 +2625,7 @@ function uxorn(x, y) {
 }
 
 function ushr(x, y) {
-  if (x < 0n)
+  if (x < BigInt(0))
     return -(-x >> y);
   return x >> y;
 }
@@ -2635,7 +2635,7 @@ function ushrn(x, y) {
 }
 
 function notn(x, width) {
-  const neg = x < 0n;
+  const neg = x < BigInt(0);
 
   if (neg)
     x = -x;
@@ -2650,14 +2650,14 @@ function notn(x, width) {
 
 function setn(x, bit, val) {
   if (val)
-    x |= (1n << BigInt(bit));
+    x |= (BigInt(1) << BigInt(bit));
   else
-    x &= ~(1n << BigInt(bit));
+    x &= ~(BigInt(1) << BigInt(bit));
   return x;
 }
 
 function usetn(x, bit, val) {
-  const neg = x < 0n;
+  const neg = x < BigInt(0);
 
   if (neg)
     x = -x;
@@ -2671,7 +2671,7 @@ function usetn(x, bit, val) {
 }
 
 function testn(x, bit) {
-  return Number((x >> BigInt(bit)) & 1n);
+  return Number((x >> BigInt(bit)) & BigInt(1));
 }
 
 function utestn(x, bit) {
@@ -2683,7 +2683,7 @@ function maskn(x, width) {
 }
 
 function umaskn(x, width) {
-  const neg = x < 0n;
+  const neg = x < BigInt(0);
 
   if (neg)
     x = -x;
@@ -2697,7 +2697,7 @@ function umaskn(x, width) {
 }
 
 function andln(x, y) {
-  if (x < 0n)
+  if (x < BigInt(0))
     x = -x;
 
   return Number(x & BigInt(y & 0x3ffffff));
@@ -2708,7 +2708,7 @@ function andln(x, y) {
  */
 
 function abs(x) {
-  return x < 0n ? -x : x;
+  return x < BigInt(0) ? -x : x;
 }
 
 /*
@@ -2753,16 +2753,16 @@ function ucmpn(x, y) {
  */
 
 function legendre(x, y) {
-  range(y > 0n, 'legendre');
+  range(y > BigInt(0), 'legendre');
 
-  if ((y & 1n) === 0n)
+  if ((y & BigInt(1)) === BigInt(0))
     throw new Error('legendre: `num` must be odd.');
 
   // Euler's criterion.
-  const s = powm(x, (y - 1n) >> 1n, y);
-  const a = ceq(s, 0n);
-  const b = ceq(s, 1n);
-  const c = ceq(s, y - 1n);
+  const s = powm(x, (y - BigInt(1)) >> BigInt(1), y);
+  const a = ceq(s, BigInt(0));
+  const b = ceq(s, BigInt(1));
+  const c = ceq(s, y - BigInt(1));
 
   // Must be one of these.
   if ((a | b | c) === 0)
@@ -2777,7 +2777,7 @@ function legendre(x, y) {
 
 // https://github.com/golang/go/blob/aadaec5/src/math/big/int.go#L754
 function jacobi(x, y) {
-  if (y === 0n || (y & 1n) === 0n)
+  if (y === BigInt(0) || (y & BigInt(1)) === BigInt(0))
     throw new Error('jacobi: `num` must be odd.');
 
   // See chapter 2, section 2.4:
@@ -2786,39 +2786,39 @@ function jacobi(x, y) {
   let b = y;
   let j = 1;
 
-  if (b < 0n) {
-    if (a < 0n)
+  if (b < BigInt(0)) {
+    if (a < BigInt(0))
       j = -1;
     b = -b;
   }
 
-  if (a < 0n)
+  if (a < BigInt(0))
     a = mod(a, b);
 
   for (;;) {
-    if (b === 1n)
+    if (b === BigInt(1))
       return j;
 
-    if (a === 0n)
+    if (a === BigInt(0))
       return 0;
 
     a %= b;
 
-    if (a === 0n)
+    if (a === BigInt(0))
       return 0;
 
     const s = zeroBits(a);
 
     if (s & 1) {
-      const bmod8 = b & 7n;
+      const bmod8 = b & BigInt(7);
 
-      if (bmod8 === 3n || bmod8 === 5n)
+      if (bmod8 === BigInt(3) || bmod8 === BigInt(5))
         j = -j;
     }
 
     const c = a >> BigInt(s);
 
-    if ((b & 3n) === 3n && (c & 3n) === 3n)
+    if ((b & BigInt(3)) === BigInt(3) && (c & BigInt(3)) === BigInt(3))
       j = -j;
 
     a = b;
@@ -2837,10 +2837,10 @@ function kronecker(x, y) {
   let b = y;
   let s = 1;
 
-  if (b === 0n)
-    return abs(a) === 1n ? s : 0;
+  if (b === BigInt(0))
+    return abs(a) === BigInt(1) ? s : 0;
 
-  if ((a & 1n) === 0n && (b & 1n) === 0n)
+  if ((a & BigInt(1)) === BigInt(0) && (b & BigInt(1)) === BigInt(0))
     return 0;
 
   const z = zeroBits(b);
@@ -2848,35 +2848,35 @@ function kronecker(x, y) {
   b >>= BigInt(z);
 
   if (z & 1)
-    s = table[Number(abs(a) & 7n)];
+    s = table[Number(abs(a) & BigInt(7))];
 
-  if (b < 0n) {
-    if (a < 0n)
+  if (b < BigInt(0)) {
+    if (a < BigInt(0))
       s = -s;
     b = -b;
   }
 
   for (;;) {
-    if (a === 0n)
-      return b === 1n ? s : 0;
+    if (a === BigInt(0))
+      return b === BigInt(1) ? s : 0;
 
     const z = zeroBits(a);
 
     a >>= BigInt(z);
 
     if (z & 1)
-      s *= table[Number(b & 7n)];
+      s *= table[Number(b & BigInt(7))];
 
-    const w = a < 0n ? ((-a) ^ 3n) : a;
+    const w = a < BigInt(0) ? ((-a) ^ BigInt(3)) : a;
 
-    if ((w & b & 2n) !== 0n)
+    if ((w & b & BigInt(2)) !== BigInt(0))
       s = -s;
 
     b = mod(b, a);
 
     [a, b] = [b, a];
 
-    if (b < 0n)
+    if (b < BigInt(0))
       b = -b;
   }
 }
@@ -2885,28 +2885,28 @@ function gcd(x, y) {
   x = abs(x);
   y = abs(y);
 
-  while (y !== 0n)
+  while (y !== BigInt(0))
     [x, y] = [y, x % y];
 
   return x;
 }
 
 function lcm(x, y) {
-  if (x === 0n || y === 0n)
-    return 0n;
+  if (x === BigInt(0) || y === BigInt(0))
+    return BigInt(0);
 
   return abs((x / gcd(x, y)) * y);
 }
 
 function egcd(x, y) {
-  let s = 0n;
-  let os = 1n;
-  let t = 1n;
-  let ot = 0n;
+  let s = BigInt(0);
+  let os = BigInt(1);
+  let t = BigInt(1);
+  let ot = BigInt(0);
   let r = abs(y);
   let or = abs(x);
 
-  while (r !== 0n) {
+  while (r !== BigInt(0)) {
     const q = or / r;
 
     [or, r] = [r, or - q * r];
@@ -2914,76 +2914,76 @@ function egcd(x, y) {
     [ot, t] = [t, ot - q * t];
   }
 
-  if (or < 0n) {
+  if (or < BigInt(0)) {
     or = -or;
     os = -os;
     ot = -ot;
   }
 
-  if (x < 0n)
+  if (x < BigInt(0))
     os = -os;
 
-  if (y < 0n)
+  if (y < BigInt(0))
     ot = -ot;
 
   return [os, ot, or];
 }
 
 function invert(x, y) {
-  assert(y > 0n);
+  assert(y > BigInt(0));
 
-  if (y === 1n)
+  if (y === BigInt(1))
     throw new RangeError('Not invertible.');
 
-  if (x < 0n || x >= y)
+  if (x < BigInt(0) || x >= y)
     x = mod(x, y);
 
-  let t = 0n;
-  let nt = 1n;
+  let t = BigInt(0);
+  let nt = BigInt(1);
   let r = y;
   let nr = x;
 
-  while (nr !== 0n) {
+  while (nr !== BigInt(0)) {
     const q = r / nr;
 
     [t, nt] = [nt, t - q * nt];
     [r, nr] = [nr, r - q * nr];
   }
 
-  if (r < 0n) {
+  if (r < BigInt(0)) {
     r = -r;
     t = -t;
   }
 
-  if (r !== 1n)
+  if (r !== BigInt(1))
     throw new RangeError('Not invertible.');
 
-  if (t < 0n)
+  if (t < BigInt(0))
     t += y;
 
   return t;
 }
 
 function fermat(x, y) {
-  assert(y > 0n);
+  assert(y > BigInt(0));
 
-  if (y === 1n)
+  if (y === BigInt(1))
     throw new RangeError('Not invertible.');
 
   // Invert using fermat's little theorem.
-  const inv = powm(x, y - 2n, y);
+  const inv = powm(x, y - BigInt(2), y);
 
-  if (inv === 0n)
+  if (inv === BigInt(0))
     throw new RangeError('Not invertible.');
 
   return inv;
 }
 
 function powm(x, e, m, size) {
-  assert(m > 0n);
+  assert(m > BigInt(0));
 
   // GMP behavior.
-  if (e < 0n) {
+  if (e < BigInt(0)) {
     x = invert(x, m);
     e = -e;
   } else {
@@ -2997,14 +2997,14 @@ function powm(x, e, m, size) {
 }
 
 function rtl(x, e, m) {
-  let r = 1n;
+  let r = BigInt(1);
 
-  while (e > 0n) {
-    if ((e & 1n) === 1n)
+  while (e > BigInt(0)) {
+    if ((e & BigInt(1)) === BigInt(1))
       r = (r * x) % m;
 
-    e >>= 1n;
-    x = (x ** 2n) % m;
+    e >>= BigInt(1);
+    x = (x ** BigInt(2)) % m;
   }
 
   return r;
@@ -3015,7 +3015,7 @@ function climb(x, e, m, size) {
   const bytes = (bits + 7) >>> 3;
   const exp = toBuffer(e, 'le', bytes);
 
-  let y = 1n;
+  let y = BigInt(1);
   let swap = 0;
 
   for (let i = bits - 1; i >= 0; i--) {
@@ -3036,22 +3036,22 @@ function climb(x, e, m, size) {
 
 // https://github.com/golang/go/blob/c86d464/src/math/big/int.go#L906
 function sqrtm(x, p) {
-  assert(p > 0n);
+  assert(p > BigInt(0));
 
-  if (x < 0n || x >= p)
+  if (x < BigInt(0) || x >= p)
     x = mod(x, p);
 
-  if ((p & 3n) === 3n)
+  if ((p & BigInt(3)) === BigInt(3))
     return sqrt3mod4(x, p);
 
-  if ((p & 7n) === 5n)
+  if ((p & BigInt(7)) === BigInt(5))
     return sqrt5mod8(x, p);
 
   return sqrt0(x, p);
 }
 
 function sqrt3mod4(x, p) {
-  const e = (p + 1n) >> 2n;
+  const e = (p + BigInt(1)) >> BigInt(2);
   const b = powm(x, e, p);
 
   if (((b * b) % p) !== x)
@@ -3061,14 +3061,14 @@ function sqrt3mod4(x, p) {
 }
 
 function sqrt5mod8(x, p) {
-  const e = p >> 3n;
-  const t = x << 1n;
+  const e = p >> BigInt(3);
+  const t = x << BigInt(1);
   const a = powm(t, e, p);
 
-  let b = (a ** 2n) % p;
+  let b = (a ** BigInt(2)) % p;
 
   b = (b * t) % p;
-  b = mod(b - 1n, p);
+  b = mod(b - BigInt(1), p);
   b = (b * x) % p;
   b = (b * a) % p;
 
@@ -3083,44 +3083,44 @@ function sqrt0(x, p) {
     case -1:
       throw new Error('X is not a square mod P.');
     case 0:
-      return 0n;
+      return BigInt(0);
     case 1:
       break;
   }
 
-  let s = p - 1n;
+  let s = p - BigInt(1);
 
   const e = BigInt(zeroBits(s));
 
   s >>= e;
 
-  let n = 2n;
+  let n = BigInt(2);
 
   while (jacobi(n, p) !== -1)
-    n += 1n;
+    n += BigInt(1);
 
-  let y = powm(x, (s + 1n) >> 1n, p);
+  let y = powm(x, (s + BigInt(1)) >> BigInt(1), p);
   let b = powm(x, s, p);
   let g = powm(n, s, p);
   let k = e;
 
   for (;;) {
     let t = b;
-    let m = 0n;
+    let m = BigInt(0);
 
-    while (t !== 1n) {
-      t = (t ** 2n) % p;
-      m += 1n;
+    while (t !== BigInt(1)) {
+      t = (t ** BigInt(2)) % p;
+      m += BigInt(1);
     }
 
-    if (m === 0n)
+    if (m === BigInt(0))
       break;
 
     assert(m !== k);
 
-    t = 1n << (k - m - 1n);
+    t = BigInt(1) << (k - m - BigInt(1));
     t = powm(g, t, p);
-    g = (t ** 2n) % p;
+    g = (t ** BigInt(2)) % p;
     y = (y * t) % p;
     b = (b * g) % p;
     k = m;
@@ -3130,8 +3130,8 @@ function sqrt0(x, p) {
 }
 
 function sqrtpq(x, p, q) {
-  assert(p > 0n);
-  assert(q > 0n);
+  assert(p > BigInt(0));
+  assert(q > BigInt(0));
 
   const sp = sqrtm(x, p);
   const sq = sqrtm(x, q);
@@ -3151,17 +3151,17 @@ function isPrimeMR(n, rng, reps, force2 = false) {
   enforce(reps > 0, 'reps', 'integer');
   enforce(typeof force2 === 'boolean', 'force2', 'boolean');
 
-  if (n < 7n) {
-    if (n === 2n || n === 3n || n === 5n)
+  if (n < BigInt(7)) {
+    if (n === BigInt(2) || n === BigInt(3) || n === BigInt(5))
       return true;
     return false;
   }
 
-  if ((n & 1n) === 0n)
+  if ((n & BigInt(1)) === BigInt(0))
     return false;
 
-  const nm1 = n - 1n;
-  const nm3 = nm1 - 2n;
+  const nm1 = n - BigInt(1);
+  const nm3 = nm1 - BigInt(2);
   const k = zeroBits(nm1);
   const q = nm1 >> BigInt(k);
 
@@ -3170,24 +3170,24 @@ next:
     let x, y;
 
     if (i === reps - 1 && force2) {
-      x = 2n;
+      x = BigInt(2);
     } else {
-      x = random(rng, 0n, nm3);
-      x += 2n;
+      x = random(rng, BigInt(0), nm3);
+      x += BigInt(2);
     }
 
     y = powm(x, q, n);
 
-    if (y === 1n || y === nm1)
+    if (y === BigInt(1) || y === nm1)
       continue;
 
     for (let j = 1; j < k; j++) {
-      y = (y ** 2n) % n;
+      y = (y ** BigInt(2)) % n;
 
       if (y === nm1)
         continue next;
 
-      if (y === 1n)
+      if (y === BigInt(1))
         return false;
     }
 
@@ -3202,19 +3202,19 @@ function isPrimeLucas(n, limit = 0) {
   enforce((limit >>> 0) === limit, 'limit', 'uint32');
 
   // Ignore 0 and 1.
-  if (n <= 1n)
+  if (n <= BigInt(1))
     return false;
 
   // Two is the only even prime.
-  if ((n & 1n) === 0n)
-    return n === 2n;
+  if ((n & BigInt(1)) === BigInt(0))
+    return n === BigInt(2);
 
   // Baillie-OEIS "method C" for choosing D, P, Q.
   // See: https://oeis.org/A217719/a217719.txt.
-  let p = 3n;
+  let p = BigInt(3);
 
   for (;;) {
-    if (p > 10000n) {
+    if (p > BigInt(10000)) {
       // Thought to be impossible.
       throw new Error(`Cannot find (D/n) = -1 for ${n.toString(10)}.`);
     }
@@ -3228,63 +3228,63 @@ function isPrimeLucas(n, limit = 0) {
       return false;
     }
 
-    const d = p * p - 4n;
+    const d = p * p - BigInt(4);
     const j = jacobi(d, n);
 
     if (j === -1)
       break;
 
     if (j === 0)
-      return n === p + 2n;
+      return n === p + BigInt(2);
 
-    if (p === 40n) {
+    if (p === BigInt(40)) {
       if (isSquare(n))
         return false;
     }
 
-    p += 1n;
+    p += BigInt(1);
   }
 
   // Check for Grantham definition of
   // "extra strong Lucas pseudoprime".
-  let s = n + 1n;
+  let s = n + BigInt(1);
   const r = zeroBits(s);
-  const nm2 = n - 2n;
+  const nm2 = n - BigInt(2);
 
-  let x = 2n;
+  let x = BigInt(2);
   let y = p;
 
   s >>= BigInt(r);
 
-  for (let i = BigInt(bitLength(s)); i >= 0n; i--) {
-    if (s & (1n << i)) {
+  for (let i = BigInt(bitLength(s)); i >= BigInt(0); i--) {
+    if (s & (BigInt(1) << i)) {
       x = mod(x * y + n - p, n);
-      y = mod(y ** 2n + nm2, n);
+      y = mod(y ** BigInt(2) + nm2, n);
     } else {
       y = mod(y * x + n - p, n);
-      x = mod(x ** 2n + nm2, n);
+      x = mod(x ** BigInt(2) + nm2, n);
     }
   }
 
-  if (x === 2n || x === nm2) {
+  if (x === BigInt(2) || x === nm2) {
     let a = x * p;
-    let b = y << 1n;
+    let b = y << BigInt(1);
 
     if (a < b)
       [a, b] = [b, a];
 
-    if (((a - b) % n) === 0n)
+    if (((a - b) % n) === BigInt(0))
       return true;
   }
 
   for (let t = 0; t < r - 1; t++) {
-    if (x === 0n)
+    if (x === BigInt(0))
       return true;
 
-    if (x === 2n)
+    if (x === BigInt(2))
       return false;
 
-    x = mod((x ** 2n) - 2n, n);
+    x = mod((x ** BigInt(2)) - BigInt(2), n);
   }
 
   return false;
@@ -3295,15 +3295,15 @@ function isPrimeLucas(n, limit = 0) {
  */
 
 function toTwos(x, width) {
-  if (x < 0n)
-    return notn(-x, width) + 1n;
+  if (x < BigInt(0))
+    return notn(-x, width) + BigInt(1);
 
   return x;
 }
 
 function fromTwos(x, width) {
   if (testn(x, width - 1))
-    return -(notn(x, width) + 1n);
+    return -(notn(x, width) + BigInt(1));
 
   return x;
 }
@@ -3313,47 +3313,47 @@ function fromTwos(x, width) {
  */
 
 function countWords(x, w) {
-  if (x === 0n)
+  if (x === BigInt(0))
     return 0;
 
-  if (x < 0n)
+  if (x < BigInt(0))
     x = -x;
 
   let i = 0;
 
   while (x >= U256_MAX) {
     i += 256;
-    x >>= 256n;
+    x >>= BigInt(256);
   }
 
   while (x >= U128_MAX) {
     i += 128;
-    x >>= 128n;
+    x >>= BigInt(128);
   }
 
   while (x >= U64_MAX) {
     i += 64;
-    x >>= 64n;
+    x >>= BigInt(64);
   }
 
   while (x >= U32_MAX) {
     i += 32;
-    x >>= 32n;
+    x >>= BigInt(32);
   }
 
   while (x >= U16_MAX) {
     i += 16;
-    x >>= 16n;
+    x >>= BigInt(16);
   }
 
   while (x >= U8_MAX) {
     i += 8;
-    x >>= 8n;
+    x >>= BigInt(8);
   }
 
-  while (x > 0n) {
+  while (x > BigInt(0)) {
     i += 1;
-    x >>= 1n;
+    x >>= BigInt(1);
   }
 
   return ((i + (w - 1)) / w) >>> 0;
@@ -3368,39 +3368,39 @@ function bitLength(x) {
 }
 
 function zeroBits(x) {
-  if (x === 0n)
+  if (x === BigInt(0))
     return 0;
 
-  if (x < 0n)
+  if (x < BigInt(0))
     x = -x;
 
   let i = 0;
 
-  while ((x & U32_MAX) === 0n) {
+  while ((x & U32_MAX) === BigInt(0)) {
     i += 32;
-    x >>= 32n;
+    x >>= BigInt(32);
   }
 
-  while ((x & U16_MAX) === 0n) {
+  while ((x & U16_MAX) === BigInt(0)) {
     i += 16;
-    x >>= 16n;
+    x >>= BigInt(16);
   }
 
-  while ((x & U8_MAX) === 0n) {
+  while ((x & U8_MAX) === BigInt(0)) {
     i += 8;
-    x >>= 8n;
+    x >>= BigInt(8);
   }
 
-  while ((x & 1n) === 0n) {
+  while ((x & BigInt(1)) === BigInt(0)) {
     i += 1;
-    x >>= 1n;
+    x >>= BigInt(1);
   }
 
   return i;
 }
 
 function word(n, pos) {
-  return Number((abs(n) >> BigInt(pos * 26)) & 0x3ffffffn);
+  return Number((abs(n) >> BigInt(pos * 26)) & BigInt(0x3ffffff));
 }
 
 /*
@@ -3408,28 +3408,28 @@ function word(n, pos) {
  */
 
 function ceq(x, y) {
-  return ((x ^ y) === 0n) | 0;
+  return ((x ^ y) === BigInt(0)) | 0;
 }
 
 function ceqn(x, y) {
-  return ((x ^ BigInt(y)) === 0n) | 0;
+  return ((x ^ BigInt(y)) === BigInt(0)) | 0;
 }
 
 function cswap(x, y, flag) {
   const bit = BigInt(flag);
-  const a = x * (bit ^ 1n) + y * bit;
-  const b = y * (bit ^ 1n) + x * bit;
+  const a = x * (bit ^ BigInt(1)) + y * bit;
+  const b = y * (bit ^ BigInt(1)) + x * bit;
   return [a, b];
 }
 
 function cinject(x, y, flag) {
   const bit = BigInt(flag);
-  return x * (bit ^ 1n) + y * bit;
+  return x * (bit ^ BigInt(1)) + y * bit;
 }
 
 function cset(x, y, flag) {
   const bit = BigInt(flag);
-  return x * (bit ^ 1n) + BigInt(y) * bit;
+  return x * (bit ^ BigInt(1)) + BigInt(y) * bit;
 }
 
 /*
@@ -3453,7 +3453,7 @@ function toString(num, base, padding) {
 
   let neg = false;
 
-  if (num < 0n) {
+  if (num < BigInt(0)) {
     neg = true;
     num = -num;
   }
@@ -3505,7 +3505,7 @@ function fromString(str, base) {
 
   const big = BigInt(base);
 
-  let num = 0n;
+  let num = BigInt(0);
 
   for (; i < str.length; i++) {
     let ch = str.charCodeAt(i);
@@ -3655,16 +3655,16 @@ function fromBuffer(data, endian) {
   const left = data.length & 7;
   const start = data.length - left;
 
-  let n = 0n;
+  let n = BigInt(0);
 
   if (ENDIAN === 'be') {
     for (let i = 0; i < arr.length; i++) {
-      n <<= 64n;
+      n <<= BigInt(64);
       n |= arr[i];
     }
 
     for (let i = start; i < data.length; i++) {
-      n <<= 8n;
+      n <<= BigInt(8);
       n |= BigInt(data[i]);
     }
 
@@ -3673,12 +3673,12 @@ function fromBuffer(data, endian) {
       n &= mask((data.length - unaligned) * 8);
   } else {
     for (let i = data.length - 1; i >= start; i--) {
-      n <<= 8n;
+      n <<= BigInt(8);
       n |= BigInt(data[i]);
     }
 
     for (let i = arr.length - 1; i >= 0; i--) {
-      n <<= 64n;
+      n <<= BigInt(64);
       n |= arr[i];
     }
 
@@ -3714,9 +3714,9 @@ function toArrayLike(n, ArrayType, endian, length) {
   if (endian === 'be') {
     let i = size - 1;
 
-    while (q > 0n) {
-      res[i--] = Number(q & 0xffn);
-      q >>= 8n;
+    while (q > BigInt(0)) {
+      res[i--] = Number(q & BigInt(0xff));
+      q >>= BigInt(8);
     }
 
     for (; i >= 0; i--)
@@ -3724,9 +3724,9 @@ function toArrayLike(n, ArrayType, endian, length) {
   } else {
     let i = 0;
 
-    while (q > 0n) {
-      res[i++] = Number(q & 0xffn);
-      q >>= 8n;
+    while (q > BigInt(0)) {
+      res[i++] = Number(q & BigInt(0xff));
+      q >>= BigInt(8);
     }
 
     for (; i < size; i++)
@@ -3744,18 +3744,18 @@ function fromArrayLike(data, endian) {
   enforce(endian === 'be' || endian === 'le', 'endian', 'endianness');
 
   if (data.length <= 0)
-    return 0n;
+    return BigInt(0);
 
-  let n = 0n;
+  let n = BigInt(0);
 
   if (endian === 'be') {
     for (let i = 0; i < data.length; i++) {
-      n <<= 8n;
+      n <<= BigInt(8);
       n |= BigInt(data[i]);
     }
   } else {
     for (let i = data.length - 1; i >= 0; i--) {
-      n <<= 8n;
+      n <<= BigInt(8);
       n |= BigInt(data[i]);
     }
   }


### PR DESCRIPTION
Replace all `BigInt` literals with `BigInt` functions.

This will allow the Node.js application bundles to be uglified and save some space on the size of the package. All code ran from the base directory of the `bcoin` gitrepo.

```bash
# without these changes, cannot use uglify-es
$ bpkg bin/node -o bcoin
$ du -h bcoin
5.3M

# with these changes, uglify-es installed globally
$ bpkg bin/node | uglifyjs > bcoin
$ du -h bcoin
4.3M

# with one additional change, removing the #!/usr/bin/env node
# this breaks the parser in bpkg/vendor/uglify-es
$ bpkg -p [ uglify-es ] bin/node -o bcoin
$ du -h bcoin
3.9M

# doing a release does uglify each file after this change
# no problems with #! like seen above
$ bpkg -p [ uglify-es ] -m -o $HOME/bcoin
```

Using `BigInt` functions over literals saves ~20% on the total package size in the end. With likely `bcoin` and `hsd` releases soon, the stylistic changes may be worth it. If you prefer the style using `BigInt` literals, we may need to implement our own `uglifyjs` that has an up to date parser. This commit can be reverted in the future when JS tooling catches up with the latest language features.

Note that when building for frontend, if the parser does not support `BigInt` literals, it should still be possible to build if the correct environment variable is present, `NODE_BACKEND=js`. Noting this here so that people can find it in the future.

Closes https://github.com/bcoin-org/bcrypto/issues/32
Closes https://github.com/bcoin-org/bcrypto/issues/14