### PR TITLE
schnorr: implement publicKeyTweakTest()

### DIFF
--- a/lib/js/schnorr.js
+++ b/lib/js/schnorr.js
@@ -334,6 +334,33 @@ class Schnorr {
     return P.encodeX();
   }
 
+  // Tweak a key with a given value and compare the result with the test key.
+  // Tweaked key may not have square Y coord, indicated by sign.
+  // See secp256k1_xonly_pubkey_tweak_test() in libsecp256k1
+  publicKeyTweakTest(key, tweak, sign, test) {
+    assert(Buffer.isBuffer(tweak));
+    assert(typeof sign === 'boolean');
+
+    if (!this.publicKeyVerify(key)
+        || !this.publicKeyVerify(test)) {
+      return false;
+    }
+
+    const P = this.curve.decodeX(key);
+    const Q = this.curve.decodeX(test);
+
+    const t = this.curve.decodeScalar(tweak);
+    if (t.cmp(this.curve.n) >= 0)
+      return false;
+    const T = this.curve.g.mul(t);
+
+    let Pt = P.add(T);
+    if (sign)
+      Pt = Pt.neg();
+
+    return Pt.eq(Q);
+  }
+
   sign(msg, key) {
     assert(Buffer.isBuffer(msg));
     assert(msg.length === 32);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,34 @@
+{
+  "name": "bcrypto",
+  "version": "4.3.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bmocha": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.3.tgz",
+      "integrity": "sha512-wKejlSjriBfiYfx3I9ngwLhQ0JY6RNfOJk/E+EsFrSYQOqbYcTKww0L4U94tcPHrkEKsZsIbLZixV2FjN6bdLw==",
+      "dev": true
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+    },
+    "bufio": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.6.tgz",
+      "integrity": "sha512-mjYZFRHmI9bk3Oeexu0rWjHFY+w6hGLabdmwSFzq+EFr4MHHsNOYduDVdYl71NG5pTPL7GGzUCMk9cYuV34/Qw=="
+    },
+    "loady": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.1.tgz",
+      "integrity": "sha512-PW5Z13Jd0v6ZcA1P6ZVUc3EV8BJwQuAiwUvvT6VQGHoaZ1d/tu7r1QZctuKfQqwy9SFBWeAGfcIdLxhp7ZW3Rw=="
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+    }
+  }
+}


### PR DESCRIPTION
This method is analogous to `secp256k1_xonly_pubkey_tweak_test()` in the branch of libsecp256k1 used in the [bip-taproot working branch](https://github.com/sipa/bitcoin/tree/taproot):

https://github.com/sipa/bitcoin/blob/e97f84c8044b4f095e16956266da9c3416dd639d/src/secp256k1/src/secp256k1.c#L839

Unlike `publicKeyTweakAdd()` this method preserves the Y coordinate of the tweaked key, and negates it based on a provided boolean argument. The tweaked-and-possibly-negated key is then tested for equality against a second public key.

This algorithm is [defined in bip-taproot](https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki#script-validation-rules) as a witness commitment check during script-path spending:

> - Let t = hashTapTweak(p || km).
> - If t ≥ 0xFFFFFFFF FFFFFFFF FFFFFFFF FFFFFFFE BAAEDCE6 AF48A03B BFD25E8C D0364141 (order of secp256k1), fail.
> - Let Q = point(q) if (c[0] & 1) = 1 and -point(q) otherwise. Fail if this point is not on the curve.
> - If Q ≠ P + int(t)G, fail.

The use of the Y-coordinate in an otherwise X-only bip-schnorr context is explained in a [footnote in bip-taproot](https://github.com/sipa/bips/blob/bip-schnorr/bip-taproot.mediawiki#cite_note-6):

> **Why is it necessary to reveal a bit to indicate if the point represented by the output public key is negated in a script path spend?** The point function (defined in bip-schnorr) always constructs a point with a square Y coordinate, but because Q is constructed by adding the taproot tweak to the internal public key P, it cannot easily be guaranteed that Q in fact has such a Y coordinate. Therefore, before verifying the taproot tweak the original point is restored by negating if necessary. We can not ignore the Y coordinate because it would prevent batch verification. Trying out multiple internal keys until there's such a Q is possible but undesirable and unnecessary since this information about the Y coordinate only consumes an unused bit.

### Testing

Official test vectors for bip-taproot have not been published yet, but I have generated a set of valid (and invalid) taproot transactions by [modifying the `feature_taproot.py` test in sipa's taproot working branch](https://github.com/pinheadmz/bitcoin/tree/taproottest1).

I have my own [in-progress Taproot branch of bcoin](https://github.com/pinheadmz/bcoin/tree/taproot1), and this new method for bcrypto/schnorr is called in this commit, which tests against the generated Taproot vectors:

https://github.com/pinheadmz/bcoin/commit/b4eb1f5ac3e67f759109d8bb7856c34cbf9f913b

I can explicitly add some of these test vectors to bcrypto if this PR is concept/approach ACK.