### PR TITLE
src/bcrypto: support nonce data in sign with secp256k1.

### DIFF
--- a/lib/native/secp256k1-libsecp256k1.js
+++ b/lib/native/secp256k1-libsecp256k1.js
@@ -382,11 +382,12 @@ function isLowDER(sig) {
  * @returns {Buffer}
  */
 
-function sign(msg, key) {
+function sign(msg, key, data) {
   assert(Buffer.isBuffer(msg));
   assert(Buffer.isBuffer(key));
+  assert(!data || Buffer.isBuffer(data));
 
-  return binding.secp256k1_sign(handle(), msg, key);
+  return binding.secp256k1_sign(handle(), msg, key, data);
 }
 
 /**
@@ -396,11 +397,12 @@ function sign(msg, key) {
  * @returns {Array}
  */
 
-function signRecoverable(msg, key) {
+function signRecoverable(msg, key, data) {
   assert(Buffer.isBuffer(msg));
   assert(Buffer.isBuffer(key));
+  assert(!data || Buffer.isBuffer(data));
 
-  return binding.secp256k1_sign_recoverable(handle(), msg, key);
+  return binding.secp256k1_sign_recoverable(handle(), msg, key, data);
 }
 
 /**
@@ -410,11 +412,12 @@ function signRecoverable(msg, key) {
  * @returns {Buffer}
  */
 
-function signDER(msg, key) {
+function signDER(msg, key, data) {
   assert(Buffer.isBuffer(msg));
   assert(Buffer.isBuffer(key));
+  assert(!data || Buffer.isBuffer(data));
 
-  return binding.secp256k1_sign_der(handle(), msg, key);
+  return binding.secp256k1_sign_der(handle(), msg, key, data);
 }
 
 /**
@@ -424,11 +427,12 @@ function signDER(msg, key) {
  * @returns {Array}
  */
 
-function signRecoverableDER(msg, key) {
+function signRecoverableDER(msg, key, data) {
   assert(Buffer.isBuffer(msg));
   assert(Buffer.isBuffer(key));
+  assert(!data || Buffer.isBuffer(data));
 
-  return binding.secp256k1_sign_recoverable_der(handle(), msg, key);
+  return binding.secp256k1_sign_recoverable_der(handle(), msg, key, data);
 }
 
 /**


### PR DESCRIPTION
Add support for passing nonce data when signing with libsecp256k1.

``` js
function sign(msg, key, data) {
```

When `data` is not passed to function `sign`, `data` will have the value of `undefined`, so existing code will work as before.