### PR TITLE
fix: handle case where the key have no cypher

### DIFF
--- a/lib/pgp.js
+++ b/lib/pgp.js
@@ -1164,6 +1164,8 @@ class CipherParams extends bio.Struct {
 
   blockSize() {
     switch (this.cipher) {
+      case cipherTypes.NONE:
+        return 0;
       case cipherTypes.IDEA:
       case cipherTypes.DES3:
       case cipherTypes.CAST5:


### PR DESCRIPTION
gpg may have packet that looks like:

  gnu-dummy S2K, algo: 0, simple checksum, hash: 0