### PR TITLE
update engine.node to 8.6 for n-api.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "bsert": "~0.0.10"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.6.0"
   },
   "gypfile": true,
   "browser": {


### PR DESCRIPTION
Until node `8.6.0` NAPI was experimental and `8.6.0` made a lot of changes.

Bcrypto only supports node from `8.6`.