### PR TITLE
Add bech32m mapping to browser field

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "./lib/encoding/base58": "./lib/encoding/base58-browser.js",
     "./lib/encoding/base64": "./lib/encoding/base64-browser.js",
     "./lib/encoding/bech32": "./lib/encoding/bech32-browser.js",
-    "./lib/encoding/bech32m.js": "./lib/encoding/bech32m-browser.js",
+    "./lib/encoding/bech32m": "./lib/encoding/bech32m-browser.js",
     "./lib/encoding/cash32": "./lib/encoding/cash32-browser.js",
     "./lib/gost94": "./lib/gost94-browser.js",
     "./lib/hash160": "./lib/hash160-browser.js",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "./lib/encoding/base58": "./lib/encoding/base58-browser.js",
     "./lib/encoding/base64": "./lib/encoding/base64-browser.js",
     "./lib/encoding/bech32": "./lib/encoding/bech32-browser.js",
+    "./lib/encoding/bech32m.js": "./lib/encoding/bech32m-browser.js",
     "./lib/encoding/cash32": "./lib/encoding/cash32-browser.js",
     "./lib/gost94": "./lib/gost94-browser.js",
     "./lib/hash160": "./lib/hash160-browser.js",


### PR DESCRIPTION
Closes https://github.com/bcoin-org/bcrypto/issues/66

`lib/encoding/bech32m.js` file is not properly replaced with `lib/encoding/bech32m-browser.js` when using the lib in the browser. The file should be mapped in` browser` field in package.json.