### PR TITLE
src/bcrypto: fix bcrypto_schnorr_verify_batch.

### DIFF
--- a/src/bcrypto.c
+++ b/src/bcrypto.c
@@ -9574,8 +9574,8 @@ bcrypto_schnorr_verify_batch(napi_env env, napi_callback_info info) {
     CHECK(napi_get_element(env, item, 2, &items[2]) == napi_ok);
 
     CHECK(napi_get_buffer_info(env, items[0], &msg, &msg_lens[i]) == napi_ok);
-    CHECK(napi_get_buffer_info(env, items[1], &pub, &sig_len) == napi_ok);
-    CHECK(napi_get_buffer_info(env, items[2], &sig, &pub_len) == napi_ok);
+    CHECK(napi_get_buffer_info(env, items[1], &sig, &sig_len) == napi_ok);
+    CHECK(napi_get_buffer_info(env, items[2], &pub, &pub_len) == napi_ok);
 
     msgs[i] = msg;
     pubs[i] = pub;


### PR DESCRIPTION
Simple issue with var names.

- `npx bmocha -B native -e BCRYPTO_FORCE_TORSION=1 ./test/schnorr-test.js -b ` was failing.

- `npx bmocha -B native ./test/schnorr-test.js -b` which uses `bcrypto_secp256k1_schnorr_verify_batch does not have the same problem. (It just is not batch).