### PR TITLE
js: use Error instead of assert.AssertionError.

### DIFF
--- a/lib/encoding/asn1.js
+++ b/lib/encoding/asn1.js
@@ -280,7 +280,7 @@ class Node extends bio.Struct {
         break;
       }
       default: {
-        throw new assert.AssertionError('Invalid mode.');
+        throw new Error('Invalid mode.');
       }
     }
 
@@ -369,7 +369,7 @@ class Node extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid mode.');
+        throw new Error('Invalid mode.');
       }
     }
   }

--- a/lib/ssh.js
+++ b/lib/ssh.js
@@ -142,7 +142,7 @@ class SSHPublicKey extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid key.');
+        throw new Error('Invalid key.');
       }
     }
 
@@ -181,7 +181,7 @@ class SSHPublicKey extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid key.');
+        throw new Error('Invalid key.');
       }
     }
 
@@ -426,7 +426,7 @@ class SSHPrivateKey extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid key.');
+        throw new Error('Invalid key.');
       }
     }
 
@@ -506,7 +506,7 @@ class SSHPrivateKey extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid key.');
+        throw new Error('Invalid key.');
       }
     }
 
@@ -588,7 +588,7 @@ class SSHPrivateKey extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid key.');
+        throw new Error('Invalid key.');
       }
     }
   }
@@ -622,7 +622,7 @@ class SSHPrivateKey extends bio.Struct {
       }
 
       default: {
-        throw new assert.AssertionError('Invalid key.');
+        throw new Error('Invalid key.');
       }
     }
 


### PR DESCRIPTION
While experimenting on ts-linter found few issues where: assert.AssertionError does not exists.

bsert was removed from production here, in favor of simpler assert: https://github.com/bcoin-org/bcrypto/commit/9ff273dee7bb76cfeb076914ac1e70aba5cacff2.

Remove last remaining usage of assert.AssertionErrors.